### PR TITLE
libviper: always use "%s"-style format for printf()-style functions

### DIFF
--- a/viper_msgbox.c
+++ b/viper_msgbox.c
@@ -104,7 +104,7 @@ viper_msgbox_create(int screen_id, char *title, float x, float y,
     if(prompt != NULL)
     {
         tmp = (width - 1 - strlen(prompt)) / 2;
-        mvwprintw(WINDOW_FRAME(vwnd), height - 3, tmp, prompt);
+        mvwprintw(WINDOW_FRAME(vwnd), height - 3, tmp, "%s", prompt);
     }
 
     if(flags & MSGBOX_TYPE_OK)

--- a/w_decorate.c
+++ b/w_decorate.c
@@ -46,7 +46,7 @@ window_decorate(WINDOW *window, char *title, bool border)
     {
         x = x / 2;
         x = x - (strlen(title) / 2);
-        mvwprintw(window, 0, x, title);
+        mvwprintw(window, 0, x, "%s", title);
     }
 
     touchwin(window);


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    libviper/viper_msgbox.c:107:9:
      error: format not a string literal and no format arguments [-Werror=format-security]
      107 |         mvwprintw(WINDOW_FRAME(vwnd), height - 3, tmp, prompt);
          |         ^~~~~~~~~

Let's wrap all the missing places with "%s" format.