### PR TITLE
menu klass skips separators during keyboard navigation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
 
 add_definitions("-D_REENTRANT")
 add_definitions("-D_GNU_SOURCE")
+add_definitions("-DNCURSES_INTERNALS")
 
 # needed for cchar_t definition and turn on "wide support"
 add_definitions("-D_XOPEN_SOURCE_EXTENDED")

--- a/klasses.txt
+++ b/klasses.txt
@@ -1,22 +1,154 @@
 
 HIERARCHY OF VK KLASSES
 
- vk_object
+ vk_object_t
    |
    +- vk_screen (todo)
    |
-   +- vk_widget   
+   +- vk_widget_t
    |    |
-   |    +- vk_container
-   |    |    | 
+   |    +- vk_container_t
+   |    |    |
    |    |    +- vk_frame (todo)
-   |    |    
-   |    +- vk_button
    |    |
-   |    +- vk_label
+   |    +- vk_button (todo)
    |    |
-   |    +- vk_spinner
+   |    +- vk_label (todo)
    |    |
-   |    +- vk_listbox
+   |    +- vk_spinner (todo)
+   |    |
+   |    +- vk_listbox_t
    |         |
-   |         + vk_menu
+   |         +- vk_menu_t
+
+
+KLASS FRAMEWORK OVERVIEW
+
+The VK klass system is a hand-rolled object-oriented type system in C.  It
+provides single inheritance, virtual dispatch via function pointers, and a
+rudimentary RTTI mechanism.
+
+
+STRUCT EMBEDDING (INHERITANCE)
+
+Each derived klass embeds its parent as the first struct member (parent_klass).
+A pointer to any derived type can be safely cast to any of its ancestors.
+Cast macros are defined in viper.h:
+
+    VK_OBJECT(x)        ->  vk_object_t *
+    VK_WIDGET(x)        ->  vk_widget_t *
+    VK_CONTAINER(x)     ->  vk_container_t *
+    VK_LISTBOX(x)       ->  vk_listbox_t *
+    VK_MENU(x)          ->  vk_menu_t *
+
+
+KLASS TEMPLATES
+
+Each type declares a global singleton "klass descriptor" using:
+
+    declare_klass(KLASS_NAME) { .size = ..., .name = ..., .ctor = ..., ... };
+    require_klass(KLASS_NAME);    // extern reference from other files
+
+These are: VK_OBJECT_KLASS, VK_WIDGET_KLASS, VK_CONTAINER_KLASS,
+VK_LISTBOX_KLASS, VK_MENU_KLASS.  The template carries the type's size, name,
+constructor, destructor, and optional kmio handler.  It serves as both the type
+descriptor and the vtable seed.
+
+
+ALLOCATION AND CONSTRUCTION
+
+vk_object_construct(klass, ...) does three things:
+
+    1. calloc(1, klass->size)  -- allocates the full derived struct
+    2. memcpy the vk_object_t header from the klass template
+    3. calls klass->ctor(object, &argp) if a ctor is installed
+
+Each derived type provides a convenience wrapper:
+
+    vk_widget_create(width, height)
+    vk_container_create(width, height)
+    vk_listbox_create(width, height)
+    vk_menu_create(width, height)
+
+
+CONSTRUCTOR CHAINING
+
+Each derived ctor explicitly calls its parent's ctor through the parent's
+klass singleton before installing its own methods:
+
+    _vk_container_ctor  -> VK_WIDGET_KLASS->ctor(object, argp)
+    _vk_listbox_ctor    -> VK_WIDGET_KLASS->ctor(object, argp)
+    _vk_menu_ctor       -> VK_LISTBOX_KLASS->ctor(object, argp)
+
+The (argp == NULL) check in each ctor distinguishes "called directly" from
+"called by a superclass" for va_list forwarding.
+
+After the parent constructs, the derived ctor overwrites the function pointer
+slots in its own struct region with its implementations.
+
+
+DESTRUCTOR CHAINING (DEMOTE PATTERN)
+
+Destruction cascades from derived to base.  A derived dtor:
+
+    1. Cleans up its own resources
+    2. Calls vk_object_demote(object, parent_type) to rewrite .name and .size
+    3. Delegates to the parent's destroy function
+
+This continues until vk_object_destroy() calls free().
+
+Example chain for vk_menu_t:
+
+    _vk_menu_dtor
+      -> vk_object_demote(object, vk_listbox_t)
+      -> vk_listbox_destroy
+        -> _vk_listbox_dtor
+          -> vk_object_demote(object, vk_widget_t)
+          -> vk_widget_destroy
+            -> _vk_widget_dtor
+              -> vk_object_demote(object, vk_object_t)
+              -> vk_object_destroy
+                -> free(object)
+
+
+RTTI (vk_object_assert)
+
+vk_object_assert(object, type) compares the object's runtime .name string and
+.size against a compile-time type.  Returns 1 if the object IS that type, 0
+otherwise.  Used as a guard in public APIs to verify klass identity before
+dispatching.
+
+
+VIRTUAL METHODS
+
+Each klass level defines function pointer slots in its struct for polymorphic
+dispatch.  Public APIs call through these pointers.
+
+    vk_object_t:      ctor, dtor, kmio
+    vk_widget_t:      ctor, dtor, _draw, _move, _resize, _erase
+    vk_container_t:   ctor, dtor, add_widget, remove_widget, vacate, rotate
+    vk_listbox_t:     ctor, dtor, _add_item, _set_item, _remove_item,
+                      _get_item, _get_item_count, _get_selected, _exec_item,
+                      _update, _reset
+    vk_menu_t:        ctor, dtor, _set_frame, _add_separator, _update, _reset
+
+
+KMIO (KEYBOARD/MOUSE I/O)
+
+The kmio function pointer on vk_object_t is the input handler.  Keystrokes
+are pushed to an object via vk_object_push_keystroke().
+
+    - vk_container_t:  forwards keystrokes to the focused child widget in
+                       its list.  KEY_TAB rotates focus.
+    - vk_listbox_t:    handles KEY_UP, KEY_DOWN, and Enter (execute item).
+    - vk_menu_t:       same as listbox but redraws with frame awareness.
+
+
+LINKED LISTS
+
+The framework uses Linux kernel-style intrusive linked lists (list.h)
+throughout:
+
+    - vk_widget_t.list          widget membership in a container
+    - vk_container_t.widget_list    children of a container
+    - vk_listbox_t.item_list    items in a listbox/menu (vk_item_t nodes)

--- a/vk_menu.c
+++ b/vk_menu.c
@@ -19,6 +19,9 @@ _vk_menu_dtor(vk_object_t *object);
 static int
 _vk_menu_kmio(vk_object_t *object, int32_t keystroke);
 
+static int
+_vk_menu_item_is_separator(vk_listbox_t *listbox, int idx);
+
 // super klass methods
 static int
 _vk_menu_set_frame(vk_menu_t *menu, int style);
@@ -181,21 +184,54 @@ _vk_menu_dtor(vk_object_t *object)
 }
 
 static int
+_vk_menu_item_is_separator(vk_listbox_t *listbox, int idx)
+{
+    vk_item_t           *item;
+    struct list_head    *pos;
+    int                 i = 0;
+
+    list_for_each(pos, &listbox->item_list)
+    {
+        if(i == idx)
+        {
+            item = list_entry(pos, vk_item_t, list);
+            return (item->separator_style > 0) ? 1 : 0;
+        }
+        i++;
+    }
+
+    return 0;
+}
+
+static int
 _vk_menu_kmio(vk_object_t *object, int32_t keystroke)
 {
     vk_menu_t       *menu;
     vk_listbox_t    *listbox;
     int             retval;
+    int             saved_item;
+    int             direction = 0;
+    int             attempts;
 
     menu = VK_MENU(object);
     listbox = VK_LISTBOX(object);
 
     if(list_empty(&listbox->item_list)) return 0;
 
+    saved_item = listbox->curr_item;
+
     switch(keystroke)
     {
-        case KEY_UP:    listbox->curr_item--;           break;
-        case KEY_DOWN:  listbox->curr_item++;           break;
+        case KEY_UP:
+            listbox->curr_item--;
+            direction = -1;
+            break;
+
+        case KEY_DOWN:
+            listbox->curr_item++;
+            direction = 1;
+            break;
+
         case 10:
         {
             retval = listbox->_exec_item(listbox);
@@ -218,6 +254,43 @@ _vk_menu_kmio(vk_object_t *object, int32_t keystroke)
         else
             listbox->curr_item--;
     }
+
+    // skip over separators in the direction of travel
+    attempts = 0;
+    while(direction != 0
+        && _vk_menu_item_is_separator(listbox, listbox->curr_item)
+        && attempts < listbox->item_count)
+    {
+        listbox->curr_item += direction;
+
+        if(listbox->curr_item < 0)
+        {
+            if(listbox->flags & VK_FLAG_ALLOW_WRAP)
+                listbox->curr_item = listbox->item_count - 1;
+            else
+            {
+                listbox->curr_item = saved_item;
+                break;
+            }
+        }
+
+        if(listbox->curr_item > (listbox->item_count - 1))
+        {
+            if(listbox->flags & VK_FLAG_ALLOW_WRAP)
+                listbox->curr_item = 0;
+            else
+            {
+                listbox->curr_item = saved_item;
+                break;
+            }
+        }
+
+        attempts++;
+    }
+
+    // all items are separators -- revert to original position
+    if(attempts >= listbox->item_count)
+        listbox->curr_item = saved_item;
 
     // now cause the widget to redraw
     menu->_update(menu);


### PR DESCRIPTION
Add separator-skipping logic to _vk_menu_kmio so KEY_UP/KEY_DOWN advance past separator items. Define NCURSES_INTERNALS to disable opaque struct mode on modern ncurses. Update klasses.txt with framework documentation.