### PR TITLE
release: libviper 5.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,26 @@
+Version 5.5.0
+
+Deck member visibility, finalize event + menubar label updates
+* [Bryan Christ] vk_deck_get_top() now returns the topmost VISIBLE member --
+  hidden (minimized) members are skipped, so focus and keyboard input hand off
+  to the next real window (callers that must walk every member regardless of
+  visibility use vk_deck_get_widget()).  The deck draw also skips a hidden
+  member's drop-shadow (previously painted before the per-widget visibility
+  gate).  With the existing vk_widget_hide() / vk_widget_show(), this is enough
+  to minimize a window in place.
+* [Bryan Christ] Add the VK_EVENT_ON_FINALIZE deck event.  vk_deck_add_widget(),
+  vk_deck_remove_widget(), vk_deck_set_top() and vk_deck_cycle() emit it once
+  the deck's membership or stacking has changed; the public vk_deck_finalize()
+  lets a consumer fire it after a change the deck can't observe itself (a
+  member's visibility).  A consumer can then re-evaluate every member in
+  z-order (vk_deck_count() / vk_deck_get_widget()) from a single handler --
+  e.g. to repaint focus decorations -- instead of hand-rolling the "who was top
+  / who is top now" dance at each call site.  A per-deck re-entrancy guard
+  prevents a handler from triggering a nested emit.  Additive; SOVERSION stays 5.
+* [Bryan Christ] Add vk_menubar_set_item_label() -- replace a menu-bar item's
+  label in place and re-render, for a live-updating label such as a count.
+  Additive; SOVERSION stays 5.
+
 Version 5.4.1
 
 Compositor scroll flicker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (!GPM_FOUND)
 add_definitions("-D_NO_GPM")
 endif()
 
-set(PROJECT_VERSION 5.4.1)
+set(PROJECT_VERSION 5.5.0)
 
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/vdk ${CMAKE_SOURCE_DIR}/vkmio)
 

--- a/vdk.h
+++ b/vdk.h
@@ -119,6 +119,9 @@ enum
 
     /* surface */
     VK_EVENT_ON_SURFACE_CHANGE = 30,
+
+    /* deck */
+    VK_EVENT_ON_FINALIZE    = 31,
 };
 
 /* keystroke definitions */
@@ -584,6 +587,7 @@ vk_widget_t*    vk_deck_get_top(vk_deck_t *deck);
 int             vk_deck_cycle(vk_deck_t *deck, int vector);
 int             vk_deck_count(vk_deck_t *deck);
 vk_widget_t*    vk_deck_get_widget(vk_deck_t *deck, int index);
+int             vk_deck_finalize(vk_deck_t *deck);
 int             vk_deck_set_shadow(vk_deck_t *deck, bool enabled);
 int             vk_deck_set_shadow_colors(vk_deck_t *deck,
                     short fg, short bg);
@@ -685,6 +689,8 @@ vk_menubar_t*   vk_menubar_create(int width);
 int             vk_menubar_add_item(vk_menubar_t *menubar,
                     char *name, VkWidgetFunc func, void *anything);
 int             vk_menubar_get_item_count(vk_menubar_t *menubar);
+int             vk_menubar_set_item_label(vk_menubar_t *menubar, int idx,
+                    char *name);
 int             vk_menubar_get_curr(vk_menubar_t *menubar);
 int             vk_menubar_set_curr(vk_menubar_t *menubar, int idx);
 int             vk_menubar_set_next(vk_menubar_t *menubar);

--- a/vdk/vk_deck.c
+++ b/vdk/vk_deck.c
@@ -53,6 +53,30 @@ vk_deck_create(void)
     return deck;
 }
 
+/*
+    Emit VK_EVENT_ON_FINALIZE so a consumer can re-evaluate every member (in
+    z-order, via vk_deck_count()/vk_deck_get_widget()) after the deck's
+    membership or stacking changes -- e.g. to repaint focus decorations
+    without each call site hand-rolling the "who was top / who is top now"
+    dance.  The mutators below fire it automatically; a consumer calls it
+    directly after changing something the deck can't observe, such as a
+    member's visibility (vk_widget_hide()/vk_widget_show()).
+*/
+int
+vk_deck_finalize(vk_deck_t *deck)
+{
+    if(deck == NULL) return -1;
+
+    /* a handler must not trigger a second, nested emit */
+    if(deck->finalizing) return 0;
+
+    deck->finalizing = true;
+    vk_object_emit(VK_OBJECT(deck), VK_EVENT_ON_FINALIZE);
+    deck->finalizing = false;
+
+    return 0;
+}
+
 inline int
 vk_deck_add_widget(vk_deck_t *deck, vk_widget_t *widget, int position)
 {
@@ -63,6 +87,8 @@ vk_deck_add_widget(vk_deck_t *deck, vk_widget_t *widget, int position)
         list_add_tail(&widget->list, &deck->widget_list);
     else
         list_add(&widget->list, &deck->widget_list);
+
+    vk_deck_finalize(deck);
 
     return 0;
 }
@@ -76,6 +102,8 @@ vk_deck_remove_widget(vk_deck_t *deck, vk_widget_t *widget)
     list_del(&widget->list);
     widget->surface = NULL;
 
+    vk_deck_finalize(deck);
+
     return 0;
 }
 
@@ -87,17 +115,29 @@ vk_deck_set_top(vk_deck_t *deck, vk_widget_t *widget)
 
     list_move(&widget->list, &deck->widget_list);
 
+    vk_deck_finalize(deck);
+
     return 0;
 }
 
 inline vk_widget_t*
 vk_deck_get_top(vk_deck_t *deck)
 {
+    struct list_head    *pos;
+    vk_widget_t         *child;
+
     if(deck == NULL) return NULL;
 
-    if(list_empty(&deck->widget_list)) return NULL;
+    /* the topmost VISIBLE member -- hidden (minimized) members are skipped so
+       focus and input hand off to the next real window.  Callers that must
+       walk every member regardless of visibility use vk_deck_get_widget(). */
+    list_for_each(pos, &deck->widget_list)
+    {
+        child = list_entry(pos, vk_widget_t, list);
+        if(child->state & VK_STATE_VISIBLE) return child;
+    }
 
-    return list_first_entry(&deck->widget_list, vk_widget_t, list);
+    return NULL;
 }
 
 inline int
@@ -111,6 +151,8 @@ vk_deck_cycle(vk_deck_t *deck, int vector)
         list_rotate_left(&deck->widget_list);
     else
         list_rotate_right(&deck->widget_list);
+
+    vk_deck_finalize(deck);
 
     return 0;
 }
@@ -238,6 +280,7 @@ _vk_deck_ctor(vk_object_t *object, va_list *argp, ...)
     deck->shadows = false;
     deck->shadow_fg = COLOR_WHITE;
     deck->shadow_bg = COLOR_BLACK;
+    deck->finalizing = false;
 
     deck->ctor = _vk_deck_ctor;
     deck->dtor = _vk_deck_dtor;
@@ -307,6 +350,11 @@ _vk_deck_draw(vk_widget_t *widget)
     {
         child = list_entry(pos, vk_widget_t, list);
         child->surface = widget->surface;
+
+        /* hidden (minimized) members: skip the shadow and the draw.  the
+           shadow is painted before vk_widget_draw's own visibility gate, so
+           without this a hidden member's drop-shadow would still leak. */
+        if(!(child->state & VK_STATE_VISIBLE)) continue;
 
         if(deck->shadows)
             _vk_deck_draw_shadow(deck, child, widget->surface);

--- a/vdk/vk_deck.h
+++ b/vdk/vk_deck.h
@@ -18,6 +18,7 @@ struct _vk_deck_s
     bool                shadows;
     short               shadow_fg;
     short               shadow_bg;
+    bool                finalizing;     /* re-entrancy guard for ON_FINALIZE */
 
     int                 (*ctor)         (vk_object_t *, va_list *, ...);
     int                 (*dtor)         (vk_object_t *);

--- a/vdk/vk_menubar.c
+++ b/vdk/vk_menubar.c
@@ -70,6 +70,45 @@ vk_menubar_add_item(vk_menubar_t *menubar, char *name,
     return menubar->_add_item(menubar, name, func, anything);
 }
 
+/*
+    Replace item `idx`'s label in place (e.g. a live count) and re-render the
+    bar.  If the new label changes the item's width, the caller should resize
+    the menubar widget to fit.  Returns 0, or -1 on a bad index / OOM.
+*/
+inline int
+vk_menubar_set_item_label(vk_menubar_t *menubar, int idx, char *name)
+{
+    vk_item_t           *item;
+    struct list_head    *pos;
+    char                *dup;
+    int                 i = 0;
+
+    if(menubar == NULL) return -1;
+    if(name == NULL || name[0] == '\0') return -1;
+    if(idx < 0 || idx >= menubar->item_count) return -1;
+
+    list_for_each(pos, &menubar->item_list)
+    {
+        if(i == idx)
+        {
+            item = list_entry(pos, vk_item_t, list);
+
+            dup = strdup(name);
+            if(dup == NULL) return -1;
+
+            if(item->name != NULL) free(item->name);
+            item->name = dup;
+
+            menubar->_update(menubar);
+
+            return 0;
+        }
+        i++;
+    }
+
+    return -1;
+}
+
 inline int
 vk_menubar_get_item_count(vk_menubar_t *menubar)
 {


### PR DESCRIPTION
Deck member visibility, finalize event, and menubar label updates.

* vk_deck_get_top() now returns the topmost VISIBLE member, so focus and input hand off past hidden (minimized) members; the deck draw also skips a hidden member's drop-shadow.  With vk_widget_hide()/show(), enough to minimize a window in place.
* Add the VK_EVENT_ON_FINALIZE deck event.  vk_deck_add_widget(), vk_deck_remove_widget(), vk_deck_set_top() and vk_deck_cycle() emit it once the deck's membership or stacking has changed, and the public vk_deck_finalize() lets a consumer fire it after a change the deck can't observe itself (a member's visibility).  A consumer re-evaluates every member in z-order from a single handler instead of hand-rolling the focus hand-off at each call site.  A per-deck re-entrancy guard prevents nested emits.
* Add vk_menubar_set_item_label() for a live-updating menu-bar label.

Additive; SOVERSION stays 5.