### PR TITLE
release: libviper 5.5.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+Version 5.5.1
+
+vk_object event/input safety fixes
+* [Bryan Christ] vk_object_emit() now walks the handler list with the _safe
+  iterator (as unregister_event and destroy already do).  A handler that
+  unregisters itself -- or another handler -- during dispatch frees its list
+  node; the non-safe walk then dereferenced the freed node via pos->next
+  (confirmed use-after-free under ASan).  Destroying the emitting object inside
+  its own handler remains unsupported -- callers must defer it (as vwm does).
+* [Bryan Christ] vk_object_push_keystroke() no longer returns an uninitialized
+  int when the target widget has no kmio -- e.g. a label or filler in a focused
+  box/grid slot, which routes the keystroke through push_keystroke.  Now returns
+  -1 in that case.
+
 Version 5.5.0
 
 Deck member visibility, finalize event + menubar label updates

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (!GPM_FOUND)
 add_definitions("-D_NO_GPM")
 endif()
 
-set(PROJECT_VERSION 5.5.0)
+set(PROJECT_VERSION 5.5.1)
 
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/vdk ${CMAKE_SOURCE_DIR}/vkmio)
 

--- a/vdk/vk_object.c
+++ b/vdk/vk_object.c
@@ -56,7 +56,7 @@ vk_object_set_kmio(vk_object_t *object, VkKmioFunc func)
 inline int
 vk_object_push_keystroke(vk_object_t *object, int32_t keystroke)
 {
-    int retval;
+    int retval = -1;        /* default when the target widget has no kmio */
 
     if(object == NULL) return -1;
 
@@ -118,10 +118,20 @@ vk_object_emit(vk_object_t *object, int event)
 {
     struct vk_event_handler *handler;
     struct list_head        *pos;
+    struct list_head        *n;
 
     if(object == NULL) return -1;
 
-    list_for_each(pos, &object->event_handlers)
+    /*
+        walk with the _safe iterator (as unregister_event and destroy already
+        do): a handler may unregister itself -- or another handler -- during
+        dispatch, freeing its list node; the non-safe walk would then
+        dereference the freed node via pos->next.  (Destroying the emitting
+        object inside its own handler remains unsupported -- that frees the
+        whole list out from under the walk, so callers must defer it, as vwm
+        does by emitting ON_CLOSE and destroying only after emit returns.)
+    */
+    list_for_each_safe(pos, n, &object->event_handlers)
     {
         handler = list_entry(pos, struct vk_event_handler, list);
 


### PR DESCRIPTION
Two vk_object safety defects (2026-07-02 review; both verified against source and reproduced).

* vk_object_emit walked the handler list with the non-safe list_for_each -- the only walker in the file that did (unregister_event and destroy use _safe).  A handler that unregisters itself (or another) during dispatch frees its node, and the walk then dereferences it via pos->next.  ASan: heap-use-after-free READ in vk_object_emit.  Switch to list_for_each_safe.  (Destroying the emitting object inside its own handler still isn't supported -- it frees the whole list; callers defer it, as vwm does.)

* vk_object_push_keystroke returned an uninitialized int when the target had no kmio -- reachable when a box/grid routes a keystroke to a passive child (label/filler).  valgrind: use of uninitialised value.  Initialize to -1.