### PR TITLE
release: libviper 5.6.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+Version 5.6.0
+
+Extended-colour surface backgrounds (API change)
+* [Bryan Christ] vk_screen_set_surface_bkgd() now takes (wchar_t wch, attr_t
+  attrs, short pair) and stores the background as a cchar_t applied via
+  wbkgrndset(), instead of a chtype via wbkgdset().  The chtype/COLOR_PAIR form
+  truncated the pair into ncurses' 8-bit A_COLOR field, so a bright (bg 12-15)
+  or 256-colour desktop background rendered in the wrong colour in the cells the
+  terminal's hardware-scroll optimisation exposes.  API break: callers pass the
+  decomposed background instead of a chtype (see vwm 4.9.2).  SOVERSION unchanged.
+
 Version 5.5.1
 
 vk_object event/input safety fixes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (!GPM_FOUND)
 add_definitions("-D_NO_GPM")
 endif()
 
-set(PROJECT_VERSION 5.5.1)
+set(PROJECT_VERSION 5.6.0)
 
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/vdk ${CMAKE_SOURCE_DIR}/vkmio)
 

--- a/vdk.h
+++ b/vdk.h
@@ -242,7 +242,7 @@ int             vk_screen_set_surface(vk_screen_t *screen, int id);
 int             vk_screen_get_active_surface(vk_screen_t *screen);
 int             vk_screen_get_surface_count(vk_screen_t *screen);
 int             vk_screen_set_surface_bkgd(vk_screen_t *screen,
-                    int surface_id, chtype bkgd);
+                    int surface_id, wchar_t wch, attr_t attrs, short pair);
 int             vk_screen_apply_stdscr_bkgd(vk_screen_t *screen);
 WINDOW*         vk_screen_get_window(vk_screen_t *screen);
 int             vk_screen_get_fd(vk_screen_t *screen);

--- a/vdk/vk_screen.c
+++ b/vdk/vk_screen.c
@@ -249,9 +249,11 @@ vk_screen_get_surface_count(vk_screen_t *screen)
     canvas avoids that without losing the flicker fix.
 */
 int
-vk_screen_set_surface_bkgd(vk_screen_t *screen, int surface_id, chtype bkgd)
+vk_screen_set_surface_bkgd(vk_screen_t *screen, int surface_id,
+    wchar_t wch, attr_t attrs, short pair)
 {
     vk_surface_t    *surface;
+    wchar_t         buf[2];
 
     if(screen == NULL) return -1;
     if(surface_id < 0 || surface_id >= screen->surface_count) return -1;
@@ -259,7 +261,13 @@ vk_screen_set_surface_bkgd(vk_screen_t *screen, int surface_id, chtype bkgd)
     surface = screen->surfaces[surface_id];
     if(surface == NULL) return -1;
 
-    surface->bkgd = bkgd;
+    /* build the bkgd as a cchar_t so it carries the pair as a full short.
+       The old chtype form went through COLOR_PAIR(), which truncates the
+       pair into the 8-bit A_COLOR field -- a bright (bg 12-15) or 256-colour
+       background then rendered in the wrong colour. */
+    buf[0] = wch;
+    buf[1] = L'\0';
+    setcchar(&surface->bkgd, buf, attrs, pair, NULL);
 
     if(surface_id == screen->active_surface)
         vk_screen_apply_stdscr_bkgd(screen);
@@ -289,7 +297,7 @@ vk_screen_apply_stdscr_bkgd(vk_screen_t *screen)
     surface = screen->surfaces[screen->active_surface];
     if(surface == NULL) return -1;
 
-    wbkgdset(stdscr, surface->bkgd);
+    wbkgrndset(stdscr, &surface->bkgd);
 
     return 0;
 }
@@ -886,6 +894,10 @@ _vk_surface_create(SCREEN *term, int width, int height)
     surface->widgets = NULL;
     surface->widget_count = 0;
     surface->widget_alloc = 0;
+
+    /* default background: a blank cell in the default pair.  A zeroed cchar_t
+       (from calloc) would carry a NUL background character. */
+    setcchar(&surface->bkgd, L" ", A_NORMAL, 0, NULL);
 
     return surface;
 }

--- a/vdk/vk_screen.h
+++ b/vdk/vk_screen.h
@@ -18,7 +18,7 @@ struct _vk_surface_s
     vk_widget_t         **widgets;
     int                 widget_count;
     int                 widget_alloc;
-    chtype              bkgd;       /* wbkgdset value; survives teleport */
+    cchar_t             bkgd;       /* wbkgrndset value; survives teleport */
 };
 
 struct _vk_screen_s


### PR DESCRIPTION
vk_screen_set_surface_bkgd: carry the full colour pair (API change).

The surface background was a chtype applied via wbkgdset(), and the pair went through COLOR_PAIR() -- which packs into ncurses' 8-bit A_COLOR field and so truncates any pair > 255.  vdk_color_pair() returns 256-319 for bright backgrounds (bg 12-15) and up to SHRT_MAX for 256-colour, so a bright/extended desktop background rendered in the wrong colour in the cells the terminal's hardware-scroll optimisation exposes (the flicker-fix path).

Store the background as a cchar_t (setcchar carries the full short pair) and apply it with wbkgrndset().  The signature changes from a chtype to (wchar_t wch, attr_t attrs, short pair); surfaces get a blank default so a zeroed cchar_t can't leave a NUL background char.  vwm's caller updates in lockstep (4.9.2).

(Stacked on fix-vk-object-safety / 5.5.1.)