### PR TITLE
spike: centralise edge-scrollbar wiring in vdk_private

### DIFF
--- a/vdk/vdk_private.c
+++ b/vdk/vdk_private.c
@@ -82,3 +82,60 @@ vdk_draw_relief(vk_widget_t *widget, int relief, short bg, attr_t extra)
         vdk_relief_wch(canvas, bottom, i, WACS_HLINE, se_pair, se_attr);
     vdk_relief_wch(canvas, bottom, right, WACS_LRCORNER, se_pair, se_attr);
 }
+
+/* see vdk_private.h -- size + place the edge scrollbars (call from _on_resize). */
+void
+vdk_scroller_reflow(vk_widget_t *widget)
+{
+    if(widget == NULL) return;
+
+    if(widget->vscroller != NULL)
+    {
+        vk_widget_resize(VK_WIDGET(widget->vscroller), 1, widget->height);
+        vk_widget_move(VK_WIDGET(widget->vscroller), widget->width - 1, 0);
+    }
+
+    if(widget->hscroller != NULL)
+    {
+        vk_widget_resize(VK_WIDGET(widget->hscroller), widget->width, 1);
+        vk_widget_move(VK_WIDGET(widget->hscroller), 0, widget->height - 1);
+    }
+}
+
+/* see vdk_private.h -- re-point the bars at the rebuilt canvas (from _recreate). */
+void
+vdk_scroller_recreate(vk_widget_t *widget)
+{
+    if(widget == NULL) return;
+
+    if(widget->vscroller != NULL)
+    {
+        VK_WIDGET(widget->vscroller)->surface = widget->canvas;
+        vk_widget_recreate(VK_WIDGET(widget->vscroller));
+    }
+
+    if(widget->hscroller != NULL)
+    {
+        VK_WIDGET(widget->hscroller)->surface = widget->canvas;
+        vk_widget_recreate(VK_WIDGET(widget->hscroller));
+    }
+}
+
+/* see vdk_private.h -- refresh + composite each visible bar (call from _update). */
+void
+vdk_scroller_draw(vk_widget_t *widget)
+{
+    if(widget == NULL) return;
+
+    if(widget->vscroller != NULL)
+    {
+        if(vk_scroller_update(widget->vscroller) > 0)
+            vk_widget_draw(VK_WIDGET(widget->vscroller));
+    }
+
+    if(widget->hscroller != NULL)
+    {
+        if(vk_scroller_update(widget->hscroller) > 0)
+            vk_widget_draw(VK_WIDGET(widget->hscroller));
+    }
+}

--- a/vdk/vdk_private.h
+++ b/vdk/vdk_private.h
@@ -57,4 +57,22 @@ void    vdk_relief_wch(WINDOW *win, int y, int x, const cchar_t *src,
 void    vdk_draw_relief(vk_widget_t *widget, int relief, short bg,
             attr_t extra);
 
+/*
+    Edge-scrollbar wiring, shared by every widget that hosts a vscroller /
+    hscroller (vk_frame, vk_listbox, vk_textbox, vk_selectbox).  The vertical
+    bar runs down the right column, the horizontal bar along the bottom row; a
+    NULL scroller is skipped.  Each helper mirrors one lifecycle step so the
+    host's _on_resize / _recreate / _update just calls the matching one instead
+    of hand-wiring both bars identically in every widget:
+
+      vdk_scroller_reflow    -- size + place the bars at the edges (_on_resize)
+      vdk_scroller_recreate  -- re-point the bars at the rebuilt canvas and
+                                recreate theirs (_recreate)
+      vdk_scroller_draw      -- refresh each bar and composite it if it wants to
+                                be shown (_update)
+*/
+void    vdk_scroller_reflow(vk_widget_t *widget);
+void    vdk_scroller_recreate(vk_widget_t *widget);
+void    vdk_scroller_draw(vk_widget_t *widget);
+
 #endif  /* _VDK_PRIVATE_H_ */

--- a/vdk/vk_frame.c
+++ b/vdk/vk_frame.c
@@ -394,17 +394,7 @@ _vk_frame_on_resize(vk_object_t *object, int event, void *anything)
     if(frame->child != NULL && (frame->child->state & VK_STATE_EXPAND))
         vk_widget_resize(frame->child, widget->width - 2, widget->height - 2);
 
-    if(widget->vscroller != NULL)
-    {
-        vk_widget_resize(VK_WIDGET(widget->vscroller), 1, widget->height);
-        vk_widget_move(VK_WIDGET(widget->vscroller), widget->width - 1, 0);
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        vk_widget_resize(VK_WIDGET(widget->hscroller), widget->width, 1);
-        vk_widget_move(VK_WIDGET(widget->hscroller), 0, widget->height - 1);
-    }
+    vdk_scroller_reflow(widget);
 
     return 0;
 }
@@ -420,17 +410,7 @@ _vk_frame_recreate(vk_widget_t *widget)
 
     frame = VK_FRAME(widget);
 
-    if(widget->vscroller != NULL)
-    {
-        VK_WIDGET(widget->vscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->vscroller));
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        VK_WIDGET(widget->hscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->hscroller));
-    }
+    vdk_scroller_recreate(widget);
 
     if(frame->child != NULL)
     {
@@ -471,17 +451,7 @@ _vk_frame_update(vk_frame_t *frame)
     widget->_erase(widget);
     frame->_draw_border(frame);
 
-    if(widget->vscroller != NULL)
-    {
-        if(vk_scroller_update(widget->vscroller) > 0)
-            vk_widget_draw(VK_WIDGET(widget->vscroller));
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        if(vk_scroller_update(widget->hscroller) > 0)
-            vk_widget_draw(VK_WIDGET(widget->hscroller));
-    }
+    vdk_scroller_draw(widget);
 
     if(frame->child != NULL)
     {

--- a/vdk/vk_listbox.c
+++ b/vdk/vk_listbox.c
@@ -8,6 +8,7 @@
 #include "vk_item.h"
 #include "vk_scroller.h"
 #include "vk_event.h"
+#include "vdk_private.h"
 
 // base klass methods
 static int
@@ -723,17 +724,7 @@ _vk_listbox_on_recreate(vk_object_t *object, int event, void *anything)
     (void)event;
     (void)anything;
 
-    if(widget->vscroller != NULL)
-    {
-        VK_WIDGET(widget->vscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->vscroller));
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        VK_WIDGET(widget->hscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->hscroller));
-    }
+    vdk_scroller_recreate(widget);
 
     return _vk_listbox_update(VK_LISTBOX(widget));
 }
@@ -746,17 +737,7 @@ _vk_listbox_on_resize(vk_object_t *object, int event, void *anything)
     (void)event;
     (void)anything;
 
-    if(widget->vscroller != NULL)
-    {
-        vk_widget_resize(VK_WIDGET(widget->vscroller), 1, widget->height);
-        vk_widget_move(VK_WIDGET(widget->vscroller), widget->width - 1, 0);
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        vk_widget_resize(VK_WIDGET(widget->hscroller), widget->width, 1);
-        vk_widget_move(VK_WIDGET(widget->hscroller), 0, widget->height - 1);
-    }
+    vdk_scroller_reflow(widget);
 
     return _vk_listbox_update(VK_LISTBOX(widget));
 }
@@ -892,17 +873,7 @@ _vk_listbox_update(vk_listbox_t *listbox)
 
     wattr_set(widget->canvas, A_NORMAL, 0, NULL);
 
-    if(widget->vscroller != NULL)
-    {
-        if(vk_scroller_update(widget->vscroller) > 0)
-            vk_widget_draw(VK_WIDGET(widget->vscroller));
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        if(vk_scroller_update(widget->hscroller) > 0)
-            vk_widget_draw(VK_WIDGET(widget->hscroller));
-    }
+    vdk_scroller_draw(widget);
 
     return 0;
 }

--- a/vdk/vk_selectbox.c
+++ b/vdk/vk_selectbox.c
@@ -9,6 +9,7 @@
 #include "vk_item.h"
 #include "vk_scroller.h"
 #include "vk_event.h"
+#include "vdk_private.h"
 
 static int
 _vk_selectbox_ctor(vk_object_t *object, va_list *argp, ...);
@@ -350,17 +351,7 @@ _vk_selectbox_update(vk_listbox_t *listbox)
 
     wattr_set(widget->canvas, A_NORMAL, 0, NULL);
 
-    if(widget->vscroller != NULL)
-    {
-        if(vk_scroller_update(widget->vscroller) > 0)
-            vk_widget_draw(VK_WIDGET(widget->vscroller));
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        if(vk_scroller_update(widget->hscroller) > 0)
-            vk_widget_draw(VK_WIDGET(widget->hscroller));
-    }
+    vdk_scroller_draw(widget);
 
     return 0;
 }
@@ -373,17 +364,7 @@ _vk_selectbox_on_resize(vk_object_t *object, int event, void *anything)
     (void)event;
     (void)anything;
 
-    if(widget->vscroller != NULL)
-    {
-        vk_widget_resize(VK_WIDGET(widget->vscroller), 1, widget->height);
-        vk_widget_move(VK_WIDGET(widget->vscroller), widget->width - 1, 0);
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        vk_widget_resize(VK_WIDGET(widget->hscroller), widget->width, 1);
-        vk_widget_move(VK_WIDGET(widget->hscroller), 0, widget->height - 1);
-    }
+    vdk_scroller_reflow(widget);
 
     return VK_LISTBOX(widget)->_update(VK_LISTBOX(widget));
 }
@@ -396,17 +377,7 @@ _vk_selectbox_on_recreate(vk_object_t *object, int event, void *anything)
     (void)event;
     (void)anything;
 
-    if(widget->vscroller != NULL)
-    {
-        VK_WIDGET(widget->vscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->vscroller));
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        VK_WIDGET(widget->hscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->hscroller));
-    }
+    vdk_scroller_recreate(widget);
 
     return VK_LISTBOX(widget)->_update(VK_LISTBOX(widget));
 }

--- a/vdk/vk_textbox.c
+++ b/vdk/vk_textbox.c
@@ -7,6 +7,7 @@
 #include "vk_scroller.h"
 #include "vk_textbox.h"
 #include "vk_event.h"
+#include "vdk_private.h"
 
 static int
 _vk_textbox_ctor(vk_object_t *object, va_list *argp, ...);
@@ -347,17 +348,7 @@ _vk_textbox_update(vk_textbox_t *textbox)
 
     wattr_set(widget->canvas, A_NORMAL, 0, NULL);
 
-    if(widget->vscroller != NULL)
-    {
-        if(vk_scroller_update(widget->vscroller) > 0)
-            vk_widget_draw(VK_WIDGET(widget->vscroller));
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        if(vk_scroller_update(widget->hscroller) > 0)
-            vk_widget_draw(VK_WIDGET(widget->hscroller));
-    }
+    vdk_scroller_draw(widget);
 
     return 0;
 }
@@ -370,17 +361,7 @@ _vk_textbox_on_resize(vk_object_t *object, int event, void *anything)
     (void)event;
     (void)anything;
 
-    if(widget->vscroller != NULL)
-    {
-        vk_widget_resize(VK_WIDGET(widget->vscroller), 1, widget->height);
-        vk_widget_move(VK_WIDGET(widget->vscroller), widget->width - 1, 0);
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        vk_widget_resize(VK_WIDGET(widget->hscroller), widget->width, 1);
-        vk_widget_move(VK_WIDGET(widget->hscroller), 0, widget->height - 1);
-    }
+    vdk_scroller_reflow(widget);
 
     _vk_textbox_reflow(VK_TEXTBOX(widget));
 
@@ -395,17 +376,7 @@ _vk_textbox_on_recreate(vk_object_t *object, int event, void *anything)
     (void)event;
     (void)anything;
 
-    if(widget->vscroller != NULL)
-    {
-        VK_WIDGET(widget->vscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->vscroller));
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        VK_WIDGET(widget->hscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->hscroller));
-    }
+    vdk_scroller_recreate(widget);
 
     return _vk_textbox_update(VK_TEXTBOX(widget));
 }


### PR DESCRIPTION
vk_frame, vk_listbox, vk_textbox and vk_selectbox each hand-wired the same vscroller/hscroller lifecycle -- byte-identical resize+place (_on_resize), surface+recreate (_recreate) and update+draw (_update) blocks.  Extract the three blocks into vdk_scroller_reflow / _recreate / _draw and call them from each host.

  4 widgets: ~132 lines of duplicated wiring -> 16 lines of helper calls
  vdk_private: +75 lines shared by all four (and any future scrollable widget)
  net -42 lines; scrollbar behaviour now lives in one place

Verified: clean build; vk_demo renders the listbox/menu/textbox scrollbars exactly as before.  Same strategy as the vdk_draw_relief centralisation.