### PR TITLE
refactor: centralise the _recreate canvas-reset in vdk_private

### DIFF
--- a/vdk/vdk_private.c
+++ b/vdk/vdk_private.c
@@ -139,3 +139,19 @@ vdk_scroller_draw(vk_widget_t *widget)
             vk_widget_draw(VK_WIDGET(widget->hscroller));
     }
 }
+
+/* see vdk_private.h -- the canvas-reset shared by every widget's _recreate. */
+int
+vdk_widget_reset_canvas(vk_widget_t *widget)
+{
+    if(widget == NULL) return -1;
+
+    if(widget->composer != widget->canvas)
+        delwin(widget->composer);
+
+    widget->canvas   = newwin(widget->height, widget->width, 0, 0);
+    widget->composer = widget->canvas;
+    widget->state   &= ~VK_STATE_FROZEN;
+
+    return (widget->canvas == NULL) ? -1 : 0;
+}

--- a/vdk/vdk_private.h
+++ b/vdk/vdk_private.h
@@ -75,4 +75,15 @@ void    vdk_scroller_reflow(vk_widget_t *widget);
 void    vdk_scroller_recreate(vk_widget_t *widget);
 void    vdk_scroller_draw(vk_widget_t *widget);
 
+/*
+    The canvas-reset every widget's _recreate performs after a teleport/resize:
+    drop the old composer if it was a separate window, make a fresh full-size
+    canvas, re-point the composer at it, and clear the FROZEN bit.  Returns 0,
+    or -1 if the widget is NULL or newwin() fails.  A _recreate calls this, then
+    re-attaches its own children/scrollers and re-renders -- so the fiddly
+    delwin/newwin/composer dance lives in exactly one place (and every widget
+    gets the same NULL-guarding, instead of the containers silently skipping it).
+*/
+int     vdk_widget_reset_canvas(vk_widget_t *widget);
+
 #endif  /* _VDK_PRIVATE_H_ */

--- a/vdk/vk_box.c
+++ b/vdk/vk_box.c
@@ -7,6 +7,7 @@
 #include "vk_container.h"
 #include "vk_box.h"
 #include "vk_event.h"
+#include "vdk_private.h"
 
 static int
 _vk_box_ctor(vk_object_t *object, va_list *argp, ...);
@@ -376,9 +377,7 @@ _vk_box_recreate(vk_widget_t *widget)
     vk_box_t    *box;
     int         i;
 
-    widget->canvas = newwin(widget->height, widget->width, 0, 0);
-    widget->composer = widget->canvas;
-    widget->state &= ~VK_STATE_FROZEN;
+    if(vdk_widget_reset_canvas(widget) < 0) return -1;
 
     box = VK_BOX(widget);
 

--- a/vdk/vk_frame.c
+++ b/vdk/vk_frame.c
@@ -404,9 +404,7 @@ _vk_frame_recreate(vk_widget_t *widget)
 {
     vk_frame_t  *frame;
 
-    widget->canvas = newwin(widget->height, widget->width, 0, 0);
-    widget->composer = widget->canvas;
-    widget->state &= ~VK_STATE_FROZEN;
+    if(vdk_widget_reset_canvas(widget) < 0) return -1;
 
     frame = VK_FRAME(widget);
 

--- a/vdk/vk_grid.c
+++ b/vdk/vk_grid.c
@@ -7,6 +7,7 @@
 #include "vk_container.h"
 #include "vk_grid.h"
 #include "vk_event.h"
+#include "vdk_private.h"
 
 static int
 _vk_grid_ctor(vk_object_t *object, va_list *argp, ...);
@@ -548,9 +549,7 @@ _vk_grid_recreate(vk_widget_t *widget)
     int         total;
     int         i;
 
-    widget->canvas = newwin(widget->height, widget->width, 0, 0);
-    widget->composer = widget->canvas;
-    widget->state &= ~VK_STATE_FROZEN;
+    if(vdk_widget_reset_canvas(widget) < 0) return -1;
 
     grid = VK_GRID(widget);
     total = grid->cols * grid->rows;

--- a/vdk/vk_label.c
+++ b/vdk/vk_label.c
@@ -5,6 +5,7 @@
 #include "vk_object.h"
 #include "vk_widget.h"
 #include "vk_label.h"
+#include "vdk_private.h"
 
 static int
 _vk_label_ctor(vk_object_t *object, va_list *argp, ...);
@@ -136,16 +137,7 @@ _vk_label_ctor(vk_object_t *object, va_list *argp, ...)
 static int
 _vk_label_recreate(vk_widget_t *widget)
 {
-    if(widget == NULL) return -1;
-
-    if(widget->composer != widget->canvas)
-        delwin(widget->composer);
-
-    widget->canvas = newwin(widget->height, widget->width, 0, 0);
-    widget->composer = widget->canvas;
-    widget->state &= ~VK_STATE_FROZEN;
-
-    if(widget->canvas == NULL) return -1;
+    if(vdk_widget_reset_canvas(widget) < 0) return -1;
 
     return _vk_label_update(VK_LABEL(widget));
 }

--- a/vdk/vk_progress.c
+++ b/vdk/vk_progress.c
@@ -276,16 +276,7 @@ _vk_progress_render(vk_widget_t *widget)
 static int
 _vk_progress_recreate(vk_widget_t *widget)
 {
-    if(widget == NULL) return -1;
-
-    if(widget->composer != widget->canvas)
-        delwin(widget->composer);
-
-    widget->canvas = newwin(widget->height, widget->width, 0, 0);
-    widget->composer = widget->canvas;
-    widget->state &= ~VK_STATE_FROZEN;
-
-    if(widget->canvas == NULL) return -1;
+    if(vdk_widget_reset_canvas(widget) < 0) return -1;
 
     return _vk_progress_render(widget);
 }

--- a/vdk/vk_widget.c
+++ b/vdk/vk_widget.c
@@ -7,6 +7,7 @@
 #include "vk_object.h"
 #include "vk_widget.h"
 #include "vk_event.h"
+#include "vdk_private.h"
 
 static int
 _vk_widget_ctor(vk_object_t *object, va_list *argp, ...);
@@ -490,16 +491,7 @@ _vk_widget_draw(vk_widget_t *widget)
 static int
 _vk_widget_recreate(vk_widget_t *widget)
 {
-    if(widget == NULL) return -1;
-
-    if(widget->composer != widget->canvas)
-        delwin(widget->composer);
-
-    widget->canvas = newwin(widget->height, widget->width, 0, 0);
-    widget->composer = widget->canvas;
-    widget->state &= ~VK_STATE_FROZEN;
-
-    return (widget->canvas == NULL) ? -1 : 0;
+    return vdk_widget_reset_canvas(widget);
 }
 
 static int

--- a/vdk/vk_window.c
+++ b/vdk/vk_window.c
@@ -8,6 +8,7 @@
 #include "vk_frame.h"
 #include "vk_scroller.h"
 #include "vk_window.h"
+#include "vdk_private.h"
 
 static int
 _vk_window_ctor(vk_object_t *object, va_list *argp, ...);
@@ -272,23 +273,11 @@ _vk_window_recreate(vk_widget_t *widget)
 {
     vk_frame_t  *frame;
 
-    widget->canvas = newwin(widget->height, widget->width, 0, 0);
-    widget->composer = widget->canvas;
-    widget->state &= ~VK_STATE_FROZEN;
+    if(vdk_widget_reset_canvas(widget) < 0) return -1;
 
     frame = VK_FRAME(widget);
 
-    if(widget->vscroller != NULL)
-    {
-        VK_WIDGET(widget->vscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->vscroller));
-    }
-
-    if(widget->hscroller != NULL)
-    {
-        VK_WIDGET(widget->hscroller)->surface = widget->canvas;
-        vk_widget_recreate(VK_WIDGET(widget->hscroller));
-    }
+    vdk_scroller_recreate(widget);
 
     if(frame->child != NULL)
     {


### PR DESCRIPTION
Every widget's _recreate repeated the same delwin/newwin/composer/FROZEN dance before re-attaching children and re-rendering.  Extract it into vdk_widget_reset_canvas() and call it from all seven (base vk_widget, label, progress, frame, grid, box, window).

- Removes the duplicated boilerplate; each _recreate is now "reset the canvas, then do my widget-specific bit".
- Fixes a latent inconsistency: the container recreates (frame/grid/box/window) skipped the NULL-widget and delwin guards the base/label/progress had -- they all get them now.
- While in vk_window, fold its inline vscroller/hscroller-recreate (missed by the earlier scroller centralisation) into vdk_scroller_recreate, so window matches frame.

Net -13 lines in vdk/; the canvas-reset primitive now lives in one place. Verified: clean build; vk_demo survives a resize (which drives _recreate on every widget) with scrollbars and word-wrap intact.