### PR TITLE
feat: vk_progress optional centred value read-out (6.1.0)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+Version 6.1.0
+
+vk_progress: optional value read-out centred in the bar
+* [Bryan Christ] Add vk_progress_set_value_text(progress, text) -- an optional
+  string drawn centred on the bar's fill axis, in reverse video, over whichever
+  cells it covers.  Each glyph inverts the cell beneath it, so the read-out
+  reads as a knockout that flips as the fill sweeps past, and its colour tracks
+  the fill (a vk_meter's zone colour) for free.  Block styles only (UNICODE /
+  ASCII) and horizontal bars -- UNDERBAR's thin baseline has nothing to knock
+  out; "" (the default) disables it.  Additive API -- SOVERSION stays 6.
+
 Version 6.0.0
 
 API BREAK: relief-style setters renamed to border-style (SOVERSION 5 -> 6)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (!GPM_FOUND)
 add_definitions("-D_NO_GPM")
 endif()
 
-set(PROJECT_VERSION 6.0.0)
+set(PROJECT_VERSION 6.1.0)
 
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/vdk ${CMAKE_SOURCE_DIR}/vkmio)
 

--- a/libviper.pc
+++ b/libviper.pc
@@ -1,6 +1,6 @@
 Name: libviper
 Description: A library for developing windowed apps on ncurses
-Version: 6.0.0
+Version: 6.1.0
 Requires: 
 prefix=/usr/local
 includedir=

--- a/vdk.h
+++ b/vdk.h
@@ -70,6 +70,9 @@ short           vdk_color_pair(short fg, short bg);
 #define VK_TROUGH_STIPPLE           1
 #define VK_TROUGH_SOLID             2
 
+/* max bytes of an optional value read-out centred on a progress/meter bar */
+#define VK_PROGRESS_VALUE_MAX       64
+
 /* separator styles */
 #define VK_SEPARATOR_BLANK          1
 #define VK_SEPARATOR_SINGLE         2
@@ -480,6 +483,8 @@ int             vk_progress_set_range(vk_progress_t *progress,
                     double min, double max);
 int             vk_progress_set_value(vk_progress_t *progress, double value);
 double          vk_progress_get_value(vk_progress_t *progress);
+int             vk_progress_set_value_text(vk_progress_t *progress,
+                    const char *text);
 int             vk_progress_set_style(vk_progress_t *progress, int style);
 int             vk_progress_set_colors(vk_progress_t *progress,
                     short fill_fg, short fill_bg);

--- a/vdk/vk_progress.c
+++ b/vdk/vk_progress.c
@@ -96,6 +96,8 @@ _vk_progress_ctor(vk_object_t *object, va_list *argp, ...)
     progress->trough_bg    = COLOR_BLACK;
     progress->trough_ch    = 0x2591;            /* U+2591 LIGHT SHADE */
 
+    progress->value_text[0] = '\0';             /* no centred read-out */
+
     progress->ctor = _vk_progress_ctor;
     progress->dtor = _vk_progress_dtor;
     progress->_fill_color = _vk_progress_default_fill_color;
@@ -266,6 +268,47 @@ _vk_progress_render(vk_widget_t *widget)
         }
     }
 
+    /*
+        Optional centred read-out: block bars only (UNDERBAR's thin baseline
+        has nothing to knock out) and horizontal only.  Each glyph is drawn in
+        reverse video over the cell it lands on, so the text reads as a knockout
+        that inverts where the fill meets the trough -- and its colour tracks
+        the fill (e.g. a meter's zone colour) for free.
+    */
+    if(progress->value_text[0] != '\0' && !underbar && !vertical)
+    {
+        wchar_t vtext[VK_PROGRESS_VALUE_MAX];
+        size_t  vn;
+        int     vw, start, crow, col, j;
+
+        vn = mbstowcs(vtext, progress->value_text, VK_PROGRESS_VALUE_MAX - 1);
+        if(vn == (size_t)-1) vn = 0;                /* invalid text: draw none */
+        vtext[vn] = L'\0';
+
+        vw = wcswidth(vtext, vn);
+        if(vw < 0) vw = (int)vn;
+
+        start = (length - vw) / 2;                  /* centre on the fill axis */
+        if(start < 0) start = 0;
+        crow  = oy + (cross - 1) / 2;               /* the bar's centre row    */
+
+        col = ox + start;
+        for(j = 0; (size_t)j < vn && (col - ox) < length; j++)
+        {
+            cchar_t glyph;
+            wchar_t gb[2];
+            int     cw = wcwidth(vtext[j]);
+            short   pr = ((col - ox) < full) ? fill_pair : trough_pair;
+
+            if(cw < 1) cw = 1;
+            gb[0] = vtext[j];
+            gb[1] = L'\0';
+            setcchar(&glyph, gb, A_REVERSE, pr, NULL);
+            mvwadd_wch(canvas, crow, col, &glyph);
+            col += cw;
+        }
+    }
+
     return 0;
 }
 
@@ -308,6 +351,29 @@ vk_progress_get_value(vk_progress_t *progress)
     if(progress == NULL) return 0.0;
 
     return progress->value;
+}
+
+/*
+    Set the read-out drawn centred on the bar (reverse video, block styles
+    only).  NULL or "" disables it.  The caller formats the string (value,
+    units, whatever); vk_progress just centres and inverts it.
+*/
+int
+vk_progress_set_value_text(vk_progress_t *progress, const char *text)
+{
+    if(progress == NULL) return -1;
+
+    if(text == NULL)
+    {
+        progress->value_text[0] = '\0';
+    }
+    else
+    {
+        strncpy(progress->value_text, text, sizeof(progress->value_text) - 1);
+        progress->value_text[sizeof(progress->value_text) - 1] = '\0';
+    }
+
+    return 0;
 }
 
 int

--- a/vdk/vk_progress.h
+++ b/vdk/vk_progress.h
@@ -42,6 +42,10 @@ struct _vk_progress_s
         only the fill colour is virtual.
     */
     void                (*_fill_color)  (vk_progress_t *, short *fg, short *bg);
+
+    /* optional read-out centred on the bar, drawn in reverse video over the
+       cells it covers (block styles only).  "" (default) disables it. */
+    char                value_text[VK_PROGRESS_VALUE_MAX];
 };
 
 #endif


### PR DESCRIPTION
Add vk_progress_set_value_text(progress, text): an optional string drawn centred on the bar's fill axis in reverse video, over whichever cells it covers. Each glyph inverts the cell beneath it, so the read-out reads as a knockout that flips where the fill meets the trough, and its colour tracks the fill (a vk_meter's zone colour) for free. Block styles only (UNICODE / ASCII) and horizontal bars; "" (the default) disables it.

Additive API -- SOVERSION stays 6; PROJECT_VERSION 6.0.0 -> 6.1.0.