### PR TITLE
fix(vk_progress): require solid trough for inline value captions (6.1.1)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+Version 6.1.1
+
+vk_progress: inline caption only with solid (or absent) trough
+* [Bryan Christ] The centred value read-out is reverse video over the cell it
+  lands on.  That requires a solid colour under each glyph.  A STIPPLE trough
+  is a shade character, not a solid field -- reverse of its pair never matches
+  the shaded body (same reason sub-cell fill already refuses stipple).
+  vk_progress_set_value_text() now returns -1 for non-empty text when the bar
+  is UNDERBAR, vertical, or has a STIPPLE trough; set_trough(STIPPLE) and
+  set_style(UNDERBAR) clear any stored caption.  Callers that want an inline
+  read-out must use UNICODE/ASCII fill with VK_TROUGH_SOLID or VK_TROUGH_NONE.
+
 Version 6.1.0
 
 vk_progress: optional value read-out centred in the bar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (!GPM_FOUND)
 add_definitions("-D_NO_GPM")
 endif()
 
-set(PROJECT_VERSION 6.1.0)
+set(PROJECT_VERSION 6.1.1)
 
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/vdk ${CMAKE_SOURCE_DIR}/vkmio)
 

--- a/libviper.pc
+++ b/libviper.pc
@@ -1,6 +1,6 @@
 Name: libviper
 Description: A library for developing windowed apps on ncurses
-Version: 6.1.0
+Version: 6.1.1
 Requires: 
 prefix=/usr/local
 includedir=

--- a/vdk.h
+++ b/vdk.h
@@ -67,10 +67,14 @@ short           vdk_color_pair(short fg, short bg);
 
 /* progress / meter trough styles */
 #define VK_TROUGH_NONE              0
-#define VK_TROUGH_STIPPLE           1
-#define VK_TROUGH_SOLID             2
+#define VK_TROUGH_STIPPLE           1   /* shade *character* -- no inline caption */
+#define VK_TROUGH_SOLID             2   /* solid colour body -- OK with caption */
 
-/* max bytes of an optional value read-out centred on a progress/meter bar */
+/* max bytes of an optional value read-out centred on a progress/meter bar.
+ * Only drawn for horizontal UNICODE/ASCII bars with a solid or absent trough
+ * (not STIPPLE, not UNDERBAR).  vk_progress_set_value_text() returns -1 if
+ * the bar is incompatible; set_trough(STIPPLE) / set_style(UNDERBAR) clear
+ * any stored caption. */
 #define VK_PROGRESS_VALUE_MAX       64
 
 /* separator styles */
@@ -483,6 +487,7 @@ int             vk_progress_set_range(vk_progress_t *progress,
                     double min, double max);
 int             vk_progress_set_value(vk_progress_t *progress, double value);
 double          vk_progress_get_value(vk_progress_t *progress);
+/* centred reverse-video read-out; see VK_PROGRESS_VALUE_MAX notes above */
 int             vk_progress_set_value_text(vk_progress_t *progress,
                     const char *text);
 int             vk_progress_set_style(vk_progress_t *progress, int style);

--- a/vdk/vk_progress.c
+++ b/vdk/vk_progress.c
@@ -269,13 +269,22 @@ _vk_progress_render(vk_widget_t *widget)
     }
 
     /*
-        Optional centred read-out: block bars only (UNDERBAR's thin baseline
-        has nothing to knock out) and horizontal only.  Each glyph is drawn in
-        reverse video over the cell it lands on, so the text reads as a knockout
-        that inverts where the fill meets the trough -- and its colour tracks
-        the fill (e.g. a meter's zone colour) for free.
+        Optional centred read-out.  Preconditions (enforced by
+        vk_progress_set_value_text / set_trough / set_style):
+          - horizontal block bar (UNICODE or ASCII, not UNDERBAR)
+          - trough is solid colour or absent -- NOT a character stipple
+
+        The read-out is reverse video over the cell it lands on: invert the
+        fill pair on filled cells and the trough pair on unfilled ones.
+        That only looks right when each cell is a solid colour.  A stipple
+        trough is a shade *character* (e.g. U+2591) on a colour pair; reverse
+        of that pair does not match the shaded body, so captions are refused
+        when trough_style is VK_TROUGH_STIPPLE (same constraint sub-cell fill
+        already has: partial blocks blend against solid troughs only).
     */
-    if(progress->value_text[0] != '\0' && !underbar && !vertical)
+    if(progress->value_text[0] != '\0'
+        && !underbar && !vertical
+        && progress->trough_style != VK_TROUGH_STIPPLE)
     {
         wchar_t vtext[VK_PROGRESS_VALUE_MAX];
         size_t  vn;
@@ -354,24 +363,35 @@ vk_progress_get_value(vk_progress_t *progress)
 }
 
 /*
-    Set the read-out drawn centred on the bar (reverse video, block styles
-    only).  NULL or "" disables it.  The caller formats the string (value,
-    units, whatever); vk_progress just centres and inverts it.
+    Set the read-out drawn centred on the bar.  NULL or "" disables it.
+
+    Requires a horizontal block bar (UNICODE / ASCII) whose trough is a
+    solid colour or absent -- reverse-video knockout needs a solid cell
+    pair under each glyph.  Returns -1 (and does not change the stored
+    text) if text is non-empty and the bar is UNDERBAR, vertical, or has
+    a character-shaded (STIPPLE) trough.
 */
 int
 vk_progress_set_value_text(vk_progress_t *progress, const char *text)
 {
     if(progress == NULL) return -1;
 
-    if(text == NULL)
+    if(text == NULL || text[0] == '\0')
     {
         progress->value_text[0] = '\0';
+        return 0;
     }
-    else
-    {
-        strncpy(progress->value_text, text, sizeof(progress->value_text) - 1);
-        progress->value_text[sizeof(progress->value_text) - 1] = '\0';
-    }
+
+    /* refuse combinations where reverse-over-cell cannot look right */
+    if(progress->style == VK_PROGRESS_UNDERBAR)
+        return -1;
+    if(progress->orientation == VK_PROGRESS_VERTICAL)
+        return -1;
+    if(progress->trough_style == VK_TROUGH_STIPPLE)
+        return -1;
+
+    strncpy(progress->value_text, text, sizeof(progress->value_text) - 1);
+    progress->value_text[sizeof(progress->value_text) - 1] = '\0';
 
     return 0;
 }
@@ -382,6 +402,10 @@ vk_progress_set_style(vk_progress_t *progress, int style)
     if(progress == NULL) return -1;
 
     progress->style = style;
+
+    /* UNDERBAR cannot host a reverse knockout -- drop any caption */
+    if(style == VK_PROGRESS_UNDERBAR)
+        progress->value_text[0] = '\0';
 
     return 0;
 }
@@ -426,6 +450,10 @@ vk_progress_set_trough(vk_progress_t *progress, int trough_style,
     progress->trough_style = trough_style;
     progress->trough_fg = fg;
     progress->trough_bg = bg;
+
+    /* character-shaded troughs cannot invert cleanly under a caption */
+    if(trough_style == VK_TROUGH_STIPPLE)
+        progress->value_text[0] = '\0';
 
     return 0;
 }


### PR DESCRIPTION
Reverse-video read-outs invert the cell under each glyph, which only works when that cell is a solid colour pair. A STIPPLE trough is a shade character; reverse of its pair never matches the shaded body (same family of constraint as sub-cell fill).

vk_progress_set_value_text() returns -1 for non-empty text when the bar is UNDERBAR, vertical, or has a STIPPLE trough. set_trough(STIPPLE) and set_style(UNDERBAR) clear any stored caption. Document the contract in vdk.h and CHANGELOG.